### PR TITLE
FOLIO-2003 initial module metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mod-codex-inventory
 
-Copyright (C) 2017-2018 The Open Library Foundation
+Copyright (C) 2017-2019 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.

--- a/README.md
+++ b/README.md
@@ -21,3 +21,8 @@ with further FOLIO Developer documentation at [dev.folio.org](https://dev.folio.
 See project [MODCXINV](https://issues.folio.org/browse/MODCXINV)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker).
 
+### ModuleDescriptor
+
+See the built `target/ModuleDescriptor.json` for the interfaces that this module
+requires and provides, the permissions, and the additional module metadata.
+

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -44,6 +44,10 @@
       ]
     }
   ],
+  "metadata": {
+    "containerMemory": "256",
+    "databaseConnection": "false"
+  },
   "permissionSets": [],
   "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",


### PR DESCRIPTION
Declare additional module metadata in ModuleDescriptor: containerMemory, databaseConnection

[FOLIO-2003](https://issues.folio.org/browse/FOLIO-2003)
