### PR TITLE
Include mandatory permissionsRequired property for each endpoint MODCXINV-45

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,14 @@ Version 2.0. See the file "[LICENSE](LICENSE)" for more information.
 
 Codex Wrapper for Inventory
 
+## Decisions
+
+### No required permissions
+
+No permissions are required to access the endpoints. These would either require the codex multiplexer or downstream clients to know about the specific codex sources, which would introduce a subtle dependency.
+
+Instead this module relies on whether the eventual client has been granted the relevant inventory storage permissions..
+
 ## Additional information
 
 ### Other documentation

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -35,11 +35,13 @@
       "handlers": [
         {
           "methods": ["GET"],
-          "pathPattern": "/codex-instances"
+          "pathPattern": "/codex-instances",
+          "permissionsRequired": []
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/codex-instances/{id}"
+          "pathPattern": "/codex-instances/{id}",
+          "permissionsRequired": []
         }
       ]
     }


### PR DESCRIPTION
Not introducing any permissions as would either require clients to be granted permissions to a specific codex implementation or for the codex multiplexer to be aware of all implementations.

Both of which seem to undermine the intent of the separation, instead relies on client being granted relevant inventory storage permissions for subsequent requests.