### PR TITLE
MODCXINV-54: Upgrade to RAML Module Builder 32.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ramlfiles_path>${basedir}/ramls/raml-util/ramls/codex</ramlfiles_path>
-    <raml-module-builder-version>31.1.0</raml-module-builder-version>
-    <vertx-version>3.9.2</vertx-version>
+    <raml-module-builder-version>32.0.0-SNAPSHOT</raml-module-builder-version>
+    <vertx-version>4.0.0</vertx-version>
   </properties>
 
   <repositories>
@@ -57,8 +57,19 @@
     <tag>HEAD</tag>
   </scm>
 
-  <dependencies>
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>${vertx-version}</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
+  <dependencies>
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
@@ -92,7 +103,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>${vertx-version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,7 @@
     <dependency>
       <groupId>org.folio.okapi</groupId>
       <artifactId>okapi-common</artifactId>
-      <version>2.35.0</version>
+      <version>4.3.0</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/src/main/java/org/folio/codex/inventory/InstanceConvert.java
+++ b/src/main/java/org/folio/codex/inventory/InstanceConvert.java
@@ -5,6 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
 
+import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.OkapiLogger;
 import org.folio.rest.jaxrs.model.Contributor;
 import org.folio.rest.jaxrs.model.Identifier;
@@ -13,7 +14,6 @@ import org.folio.rest.jaxrs.model.InstanceCollection;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
 
 public class InstanceConvert {
 

--- a/src/main/java/org/folio/codex/inventory/QueryConvert.java
+++ b/src/main/java/org/folio/codex/inventory/QueryConvert.java
@@ -1,13 +1,12 @@
 package org.folio.codex.inventory;
 
-import io.vertx.core.logging.Logger;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+
 import org.folio.okapi.common.CQLUtil;
-import org.folio.okapi.common.OkapiLogger;
 import org.z3950.zing.cql.CQLAndNode;
 import org.z3950.zing.cql.CQLBooleanNode;
 import org.z3950.zing.cql.CQLNode;
@@ -28,10 +27,7 @@ import org.z3950.zing.cql.UnknownRelationModifierException;
 @java.lang.SuppressWarnings({"squid:S1192"})
 public class QueryConvert {
 
-  Logger logger = OkapiLogger.get();
-
-  class IndexDescriptor {
-
+  static class IndexDescriptor {
     final String name;
     final boolean filter;
 

--- a/src/main/java/org/folio/codex/inventory/QueryConvert.java
+++ b/src/main/java/org/folio/codex/inventory/QueryConvert.java
@@ -6,7 +6,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
-import org.folio.okapi.common.CQLUtil;
+import org.folio.okapi.common.CqlUtil;
 import org.z3950.zing.cql.CQLAndNode;
 import org.z3950.zing.cql.CQLBooleanNode;
 import org.z3950.zing.cql.CQLNode;
@@ -208,15 +208,15 @@ public class QueryConvert {
       -> n1.getIndex().equals(n2.getIndex()) ? 0 : -1;
 
     CQLTermNode source = new CQLTermNode("source", rel, "local");
-    if (!CQLUtil.eval(top, source, f1)) {
+    if (!CqlUtil.eval(top, source, f1)) {
       return null;
     }
-    CQLNode n2 = CQLUtil.reducer(top, source, f2);
+    CQLNode n2 = CqlUtil.reducer(top, source, f2);
     if (n2 == null) {
       throw new IllegalArgumentException("query has source clause only");
     }
     CQLTermNode extSelected = new CQLTermNode("ext.selected", rel, null);
-    n2 = CQLUtil.reducer(n2, extSelected, f2);
+    n2 = CqlUtil.reducer(n2, extSelected, f2);
     if (n2 == null) {
       throw new IllegalArgumentException("query has ext.selected clause only");
     }

--- a/src/test/java/org/folio/codex/inventory/CodexInventoryTest.java
+++ b/src/test/java/org/folio/codex/inventory/CodexInventoryTest.java
@@ -3,6 +3,8 @@ package org.folio.codex.inventory;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -14,8 +16,6 @@ import io.vertx.core.http.HttpServerOptions;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
@@ -32,14 +32,9 @@ import org.folio.rest.jaxrs.model.ResultInfo;
 
 @RunWith(VertxUnitRunner.class)
 public class CodexInventoryTest {
-
-  static {
-    System.setProperty(LoggerFactory.LOGGER_DELEGATE_FACTORY_CLASS_NAME, "io.vertx.core.logging.Log4j2LogDelegateFactory");
-  }
-
   private final int portInventory = 9030;
   private final int portCodex = 9031;
-  private final Logger logger = LoggerFactory.getLogger("codex.inventory");
+  private final Logger logger = LogManager.getLogger("codex.inventory");
   private String failMap; // for non-null value signals provoked failure
   private String failInventory; // for non-null value signals provoked failure
 
@@ -164,7 +159,6 @@ public class CodexInventoryTest {
   };
 
   private void handlerGetByQuery(RoutingContext ctx) {
-    final String query = ctx.request().getParam("query");
     ctx.request().endHandler(res -> {
       JsonArray instances = new JsonArray();
       JsonObject rec = new JsonObject(records[0]);

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -1,0 +1,19 @@
+status = error
+name = PropertiesConfig
+packages = org.folio.okapi.common.logging
+
+filters = threshold
+
+filter.threshold.type = ThresholdFilter
+filter.threshold.level = info
+
+appenders = console
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-20.20C{1} %m%n
+
+rootLogger.level = info
+rootLogger.appenderRefs = info
+rootLogger.appenderRef.stdout.ref = STDOUT

--- a/src/test/resources/log4j2-test.properties
+++ b/src/test/resources/log4j2-test.properties
@@ -12,7 +12,7 @@ appenders = console
 appender.console.type = Console
 appender.console.name = STDOUT
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{HH:mm:ss} %-5p %-20.20C{1} %m%n
+appender.console.layout.pattern = %d{HH:mm:ss} [$${FolioLoggingContext:requestid}] [$${FolioLoggingContext:tenantid}] [$${FolioLoggingContext:userid}] [$${FolioLoggingContext:moduleid}] %-5p %-20.20C{1} %m%n
 
 rootLogger.level = info
 rootLogger.appenderRefs = info


### PR DESCRIPTION
## Changes:
* Use RMB `32.0.0-SNAPSHOT`
* Use WebClient instead of HttpClient;
* Do not use vertx logger.