### PR TITLE
MODCXINV-58: Allow instance-storage 8.0 with optimistic locking version

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "requires": [
     {
       "id": "instance-storage",
-      "version": "7.0"
+      "version": "7.0 8.0"
     },
     {
       "id": "contributor-name-types",

--- a/src/test/java/org/folio/codex/inventory/CodexInventoryTest.java
+++ b/src/test/java/org/folio/codex/inventory/CodexInventoryTest.java
@@ -99,6 +99,7 @@ public class CodexInventoryTest {
   private final String[] records = {""
     + "  {\n"
     + "    \"id\" : \"" + ID1 + "\",\n"
+    + "    \"_version\" : 5,\n"
     + "    \"source\" : \"Sample\",\n"
     + "    \"title\" : \"Transparent water\",\n"
     + "    \"alternativeTitles\" : [ {\n"


### PR DESCRIPTION
Allow interface instance-storage 8.0
that adds the `_version` property
to instance records for optimistic locking.

mod-codex-inventory picks a few instance properties:
https://github.com/folio-org/mod-codex-inventory/blob/v1.9.0/src/main/java/org/folio/codex/inventory/InstanceConvert.java#L47-L63
https://github.com/folio-org/raml/blob/1d92b1079e865cd5830f49d73c21a9a27f1800e0/schemas/codex/instance.json

Therefore no code change is needed, all mod-codex-inventory interfaces remain unchanged.