### PR TITLE
MODCXINV-61: Update RMB to 33.0.4 (Kiwi R3 2021).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 2.1.1 IN-PROGRESS
+
+* Update RMB to 33.0.4. (CVE-2021-44228) (MODCXINV-61)
+
 ## 2.1.0 2021-10-05
 
 * Requires `instance-storage 7.0 or 8.0`

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <ramlfiles_path>${basedir}/ramls/raml-util/ramls/codex</ramlfiles_path>
-    <raml-module-builder-version>33.0.0</raml-module-builder-version>
+    <raml-module-builder-version>33.0.4</raml-module-builder-version>
     <vertx-version>4.1.0.CR1</vertx-version>
   </properties>
 


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODCXINV-61](https://issues.folio.org/browse/MODCXINV-61).