### PR TITLE
MODCXINV-70: Support instance-storage 9.0 interface

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## IN-PROGRESS
+
+* Requires `instance-storage` `9.0` ([MODCXINV-70](https://issues.folio.org/browse/MODCXINV-70))
+
 ## 2.3.0 2022-06-15
 
 * Upgrade to RMB to 34.0.0 ([MODCXINV-68](https://issues.folio.org/browse/MODCXINV-68))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "requires": [
     {
       "id": "instance-storage",
-      "version": "7.0 8.0"
+      "version": "7.0 8.0 9.0"
     },
     {
       "id": "contributor-name-types",


### PR DESCRIPTION
mod-inventory-storage has new major interface versions:

instance-storage 9.0
holdings-storage 6.0
item-storage 10.0

mod-codex-inventory uses only instance-storage, it doesn't use the other two interfaces.

mod-codex-inventory is not affected because the incompatible change is in the DELETE all APIs only that is not used by mod-codex-inventory.

Only the okapiInterfaces need to be bumped in "requires" section of ModuleDescriptor-template.json